### PR TITLE
add did:facebook: method spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         </td>
     </tr>
 
+    <tr>
+        <td>
+            did:facebook:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            Facebook
+        </td>
+        <td>
+            Markus Sabadello
+        </td>
+        <td>
+            <a href="https://github.com/peacekeeper/did-method-facebook/blob/master/did-method-facebook.md">Facebook DID Method</a>
+        </td>
+    </tr>
+
   </tbody>
 </table>
 


### PR DESCRIPTION
Hey I have an idea for a cool new DID method spec - based on Facebook accounts!

Here is the method spec: https://github.com/peacekeeper/did-method-facebook/blob/master/did-method-facebook.md

**NOTE: This is not a serious proposal for a new DID method, but rather a thought experiment about the nature and objectives of DIDs.**

Also see https://github.com/w3c-ccg/did-method-registry/pull/25