### PR TITLE
Request inclusion for 'did:bryk:'

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,12 +137,12 @@ registry, an implementer MUST:
   <li>
     Implement at least an experimental version of the new DID Method.
   </li>
-  <li>Create a specification describing the new DID Method that is publicly 
-    available and intended to be conformant with the DID specification at 
+  <li>Create a specification describing the new DID Method that is publicly
+    available and intended to be conformant with the DID specification at
     <a href="https://w3c-ccg.github.io/did-spec/">https://w3c-ccg.github.io/did-spec/</a>.</li>
   <li>
     Request that the specification be added to this registry by submitting a
-    Github Pull Request that adds the new method to the list of existing 
+    Github Pull Request that adds the new method to the list of existing
     methods, with URL.
   </li>
 </ol>
@@ -213,7 +213,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
       </td>
     </tr>
 
-    
+
     <tr>
       <td>
           did:cnsnt:
@@ -495,8 +495,8 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <td>
           <a href="https://github.com/oceanprotocol/OEPs/blob/master/7/did-method-spec.md">Ocean Protocol DID Method</a>
         </td>
-    </tr>    	  
-    
+    </tr>
+
     <tr>
         <td>
             did:jlinc:
@@ -514,7 +514,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           <a href="https://did-spec.jlinc.org/">JLINC Protocol DID Method</a>
         </td>
     </tr>
-	  
+
     <tr>
         <td>
             did:ion:
@@ -532,7 +532,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           <a href="https://github.com/decentralized-identity/ion-did-method">ION DID Method</a>
         </td>
     </tr>
-	  
+
     <tr>
         <td>
             did:jolo:
@@ -565,6 +565,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         </td>
         <td>
             <a href="https://github.com/uport-project/ethr-did-resolver/blob/develop/doc/did-method-spec.md">ETHR DID Method</a>
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            did:bryk:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            bryk
+        </td>
+        <td>
+            Marcos Allende, Sandra Murcia, Flavia Munhoso, Ruben Cessa
+        </td>
+        <td>
+            <a href="https://github.com/bryk-io/did-method/blob/master/README.md">bryk DID Method</a>
         </td>
     </tr>
 


### PR DESCRIPTION
An initial public release is published, pre-built binaries for Linux, Windows, and MacOS are available to facilitate testing.

https://github.com/bryk-io/did-method/releases/tag/v0.1.0