### PR TITLE
[Do not merge] Key Transparency DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,6 +619,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             <a href="https://github.com/SelfKeyFoundation/selfkey-identity/blob/develop/DIDMethodSpecs.md">SelfKey DID Method</a>
         </td>
     </tr>
+    <tr>
+        <td>
+            did:kt:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            Key Transparency System
+        </td>
+        <td>
+            Kim Hamilton Duffy
+        </td>
+        <td>
+            <a href="https://github.com/kimdhamilton/did-method-kt/blob/master/README.md">Key Transparency DID Method</a>
+        </td>
+    </tr>	  
   </tbody>
 </table>
 


### PR DESCRIPTION
This isn't yet ready to merge, or even review yet

@peacekeeper's thought experiment facebook DID method inspired me to create my own weird DID method, bridging to google's key transparency project. The reasons this could be interesting are outlined in the abstract.

**_I am not sure this is a good idea_**. Clearly the spec alone needs details (this involves a generated DID document, like BTCR), but I need to handle oddities stemming from direct vs indirect use of this DID method.

Other big TODOs before I remove the “do not merge” label:
- details on generated did document
- update details
- delete details
Current draft:
https://github.com/kimdhamilton/did-method-kt/blob/master/README.md