### PR TITLE
Created Halialabs Emtrust DID method spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,6 +671,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             <a href="https://github.com/dhuseby/did-git-spec/blob/master/did-git-spec.md">Git DID Method</a>
         </td>
     </tr>
+    <tr>
+        <td>
+            did:emtrust:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            DID Specification
+        </td>
+        <td>
+            Halialabs
+        </td>
+        <td>
+            <a href="https://github.com/Halialabs/did-spec/blob/gh-pages/readme.md">Emtrust DID Method</a>
+        </td>
+    </tr>
   </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -679,10 +679,10 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             PROVISIONAL
         </td>
         <td>
-            DID Specification
+            Hyperledger Fabric
         </td>
         <td>
-            Halialabs
+            Sunil Prakash
         </td>
         <td>
             <a href="https://github.com/Halialabs/did-spec/blob/gh-pages/readme.md">Emtrust DID Method</a>

--- a/index.html
+++ b/index.html
@@ -673,6 +673,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
     </tr>
     <tr>
         <td>
+            did:tangle:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            IOTA Tangle
+        </td>
+        <td>
+            BiiLabs Co., Ltd.
+        </td>
+        <td>
+            <a href="https://github.com/TangleID/TangleID/blob/develop/did-method-spec.md">TangleID DID Method</a>
+        </td>
+    </tr>
+    <tr>
+        <td>
             did:emtrust:
         </td>
         <td>
@@ -682,7 +699,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             Hyperledger Fabric
         </td>
         <td>
-            Sunil Prakash
+            Halialabs Pte Ltd.
         </td>
         <td>
             <a href="https://github.com/Halialabs/did-spec/blob/gh-pages/readme.md">Emtrust DID Method</a>


### PR DESCRIPTION
Created Halialabs DID method spec. The implementation is in active development. It is based on Hyperledger fabric, to enable DID for provisioned blockchain