### PR TITLE
Add entry for did:web method.

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <td>
             <a href="https://openssi.github.io/peer-did-method-spec/index.html">peer DID Method</a>
         </td>
-    </tr> 
+    </tr>
     <tr>
         <td>
             did:selfkey:
@@ -708,7 +708,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
     </tr>
     <tr>
         <td>
-            did:ttm: 
+            did:ttm:
         </td>
         <td>
             PROVISIONAL
@@ -773,7 +773,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
 	<td>
 	    <a href="https://github.com/WebOfTrustInfo/rwot9-prague/blob/master/draft-documents/did:hc-method.md">Holochain DID Method</a>
 	</td>
-    </tr>	  
+    </tr>
+    <tr>
+      <td>
+        did:web:
+      </td>
+      <td>
+        PROVISIONAL
+      </td>
+      <td>
+        Web
+      </td>
+      <td>
+        Oliver Terbu, Mike Xu, Dmitri Zagidulin, Amy Guy
+      </td>
+      <td>
+        <a href="https://github.com/w3c-ccg/did-method-web">Web DID Method</a>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Adding the [`did:web` method](https://github.com/w3c-ccg/did-method-web) (which is now a CCG Work Item, and which has sparked the discussion that led to the DID Rubrics document) to the registry.