### PR TITLE
Add Baidu Cloud DID Method

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,6 +895,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <a href="https://github.com/vpayment/did-method-spec/blob/master/vid.md">VP DID Method</a>
       </td>
     </tr>	  
+    <tr>
+        <td>
+          did:ccp:
+        </td>
+        <td>
+          PROVISIONAL
+        </td>
+        <td>
+          Quorum
+        </td>
+        <td>
+          Baidu, Inc.
+        </td>
+        <td>
+          <a href="https://did.baidu.com/did-spec/">Cloud DID Method</a>
+        </td>
+    </tr>
    
   </tbody>
 </table>


### PR DESCRIPTION
Cloud DID is the [Baidu](http://ir.baidu.com/)  implementation of DID(Decentralized ID). It relies on the W3C standards providing **DID** and **Verifiable Credential Claim**.

We create this PR to add [Baidu Cloud DID Method Spec](https://did.baidu.com/did-spec/).

More details:
- [Solution Homepage](https://cloud.baidu.com/solution/digitalIdentity.html)
- [Docs Homepage](https://did.baidu.com)

Related PRs:
-  **[Merged]** PR on the DID Universal Resolver: https://github.com/decentralized-identity/universal-resolver/pull/62

Thank you for reviewing.