### PR TITLE
Add teleinfo did:bid   method.

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <td>
             <a href="https://openssi.github.io/peer-did-method-spec/index.html">peer DID Method</a>
         </td>
-    </tr> 
+    </tr>
     <tr>
         <td>
             did:selfkey:
@@ -708,7 +708,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
     </tr>
     <tr>
         <td>
-            did:ttm: 
+            did:ttm:
         </td>
         <td>
             PROVISIONAL
@@ -773,7 +773,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
 	<td>
 	    <a href="https://github.com/WebOfTrustInfo/rwot9-prague/blob/master/draft-documents/did:hc-method.md">Holochain DID Method</a>
 	</td>
-    </tr>	  
+    </tr>
+    <tr>
+      <td>
+        did:web:
+      </td>
+      <td>
+        PROVISIONAL
+      </td>
+      <td>
+        Web
+      </td>
+      <td>
+        Oliver Terbu, Mike Xu, Dmitri Zagidulin, Amy Guy
+      </td>
+      <td>
+        <a href="https://github.com/w3c-ccg/did-method-web">Web DID Method</a>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
BID provides distributed identifiers and blockchain digital identity services for people, enterprises, devices and digital objects. It aims to build a decentralized, data-secure, privacy-protected and flexible identifier system that addresses trusted connections to people, enterprises, devices and digital objects，enabling the vision of the Internet of Everything and trust ingress with everything.

We create this PR to add [BIF DID protocol Specification](https://github.com/teleinfo-bif/bid/blob/master/doc/en/BIF%20DID%20protocol%20Specification_up.md)