### PR TITLE
Update Authors to did:icon method

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           ICON Foundation
       </td>
       <td>
-        <a href="https://github.com/icon-project/icon-DID/blob/master/docs/en/DID-ICON-method.md">ICON DID Method</a>
+        <a href="https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md">ICON DID Method</a>
       </td>
     </tr>
 

--- a/index.html
+++ b/index.html
@@ -444,9 +444,6 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <a href="https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md">ICON DID Method</a>
       </td>
     </tr>
-<<<<<<< HEAD
-
-=======
 	<tr>
       <td>
           did:iwt:
@@ -916,7 +913,6 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         </td>
     </tr>
    
->>>>>>> 89e7279cf0a03dcad39507333fc504590c739a0f
   </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           ICON
       </td>
       <td>
-          ICON Foundation
+          ICONLOOP
       </td>
       <td>
         <a href="https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md">ICON DID Method</a>

--- a/index.html
+++ b/index.html
@@ -407,6 +407,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <a href="https://vivvo.github.io/vivvo-did-scheme/spec/did-method-spec-template.html">Vivvo DID Method</a>
       </td>
     </tr>
+    <tr>
+      <td>
+          did:icon:
+      </td>
+      <td>
+          PROVISIONAL
+      </td>
+      <td>
+          ICON
+      </td>
+      <td>
+          ICON Foundation
+      </td>
+      <td>
+        <a href="https://github.com/icon-project/icon-DID/blob/master/docs/en/DID-ICON-method.md">ICON DID Method</a>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 


### PR DESCRIPTION
ICON DID method is used in ICON Network managed by ICON Foundation but has been developed and provided by ICONLOOP, ICON Foundation's tech partner. So we kindly request for the change of Author name from ICON Foundation to ICONLOOP.