### PR TITLE
Added Commercio.Network DID Method

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <a href="https://w3c-ccg.github.io/didm-veres-one/">Veres One DID Method</a>
       </td>
     </tr>
-
+    <tr>
+      <td>
+          did:com:
+      </td>
+      <td>
+          PROVISIONAL
+      </td>
+      <td>
+          commercio.network
+      </td>
+      <td>
+          Commercio Consortium
+      </td>
+      <td>
+          <a href="https://github.com/commercionetwork/Commercio.network-DID-Method-Specification/">Commercio.network DID Method</a>
+      </td>
+    </tr>
     <tr>
       <td>
           did:dom:


### PR DESCRIPTION
We just added to the registry commercio.network DID method specification.
Some info about the project:
- [commercio.network portal](https://commercio.network/)
- [commercio.network developer portal](https://docs.commercio.network/developers/)
- [full node installation procedure](https://docs.commercio.network/nodes/)
- [commercio.network testnet explorer](https://testnet.commercio.network/)

thanks in advance
Egidio
