### PR TITLE
Add did:bid:method

### DIFF
--- a/index.html
+++ b/index.html
@@ -947,7 +947,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <td>
           <a href="https://github.com/jnctn/did-method-spec/">JNCTN DID Method</a>
         </td>
-      </tr>	  
+      </tr>	
+<tr>
+        <td>
+          did:bid:
+        </td>
+        <td>
+          PROVISIONAL
+        </td>
+        <td>
+          bif
+        </td>
+        <td>
+          teleinfo.
+        </td>
+        <td>
+          <a href="https://github.com/teleinfo-bif/bid/blob/master/doc/en/BIF%20DID%20protocol%20Specification_up.md">BIF DID Method</a>
+        </td>
+    </tr>
   </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -959,7 +959,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           bif
         </td>
         <td>
-          teleinfo
+          teleinfo caict
         </td>
         <td>
           <a href="https://github.com/teleinfo-bif/bid/blob/master/doc/en/BIF%20DID%20protocol%20Specification_up.md">BIF DID Method</a>

--- a/index.html
+++ b/index.html
@@ -959,7 +959,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           bif
         </td>
         <td>
-          teleinfo.
+          teleinfo
         </td>
         <td>
           <a href="https://github.com/teleinfo-bif/bid/blob/master/doc/en/BIF%20DID%20protocol%20Specification_up.md">BIF DID Method</a>

--- a/index.html
+++ b/index.html
@@ -962,7 +962,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           teleinfo caict
         </td>
         <td>
-          <a href="https://github.com/teleinfo-bif/bid/blob/master/doc/en/BIF%20DID%20protocol%20Specification_up.md">BIF DID Method</a>
+          <a href="https://github.com/teleinfo-bif/bid/tree/master/doc/en">BIF DID Method</a>
         </td>
     </tr>
   </tbody>


### PR DESCRIPTION
BID provides distributed identifiers and blockchain digital identity services for people, enterprises, devices and digital objects. It aims to build a decentralized, data-secure, privacy-protected and flexible identifier system that addresses trusted connections to people, enterprises, devices and digital objects，enabling the vision of the Internet of Everything and trust ingress with everything.

We create this PR to add [BIF DID protocol Specification](https://github.com/teleinfo-bif/bid/tree/master/doc/en)