### PR TITLE
Add did:github

### DIFF
--- a/index.html
+++ b/index.html
@@ -947,7 +947,25 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         <td>
           <a href="https://github.com/jnctn/did-method-spec/">JNCTN DID Method</a>
         </td>
-      </tr>	  
+    </tr>	  
+
+    <tr>
+        <td>
+          did:github:
+        </td>
+        <td>
+          PROVISIONAL
+        </td>
+        <td>
+          Github
+        </td>
+        <td>
+          Transmute
+        </td>
+        <td>
+          <a href="https://github.com/decentralized-identity/github-did/">GitHub DID Method</a>
+        </td>
+    </tr>	  
   </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           Transmute
         </td>
         <td>
-          <a href="https://github.com/decentralized-identity/github-did/">GitHub DID Method</a>
+          <a href="https://github.com/decentralized-identity/github-did/blob/master/packages/docs/did-method-spec/spec.md">GitHub DID Method</a>
         </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The github method is meant to make working with DIDs very simple at the cost of trusting Github.com for assisting in resolving DID Documents.

Many developers are familar with Github, and its 2 supported public key cryptosystems, GPG and SSH.

Linked Data Signatures are difficult to work with when operating a server or running a local node of some distributed system / blockchain is a requirement.

The objective of GitHub DID is to encourage contribution to the DID Spec and Linked Data Signatures, and allow rapid development of extensions to these without requiring the use of slow, or complicated more trustless infrastructure, such as blockchains or other distributed systems.

GitHub DID is hosted by DIF: https://github.com/decentralized-identity/github-did/