### PR TITLE
Add Elastos DID Method

### DIFF
--- a/index.html
+++ b/index.html
@@ -948,6 +948,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           <a href="https://github.com/jnctn/did-method-spec/">JNCTN DID Method</a>
         </td>
       </tr>	  
+    <tr>
+        <td>
+          did:elastos:
+        </td>
+        <td>
+          PROVISIONAL
+        </td>
+        <td>
+          Elastos ID Sidechain
+        </td>
+        <td>
+          Elastos Foundation
+        </td>
+        <td>
+          <a href="https://github.com/elastos/Elastos.DID.Method/blob/master/DID/Elastos-DID-Method-Specification_en.md">Elastos DID Method</a>
+        </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Elastos DID is the DID implemented by Elastos. It follows the W3C's DID specification and provides DID Method, Verifiable Credentials Claim and Resolve.

We have released the Elastos.DID.Java.SDK based on the Elastos DID Method. The ID SIdechain for storing DID data has been launched.

More information:

1. [DID Method](https://github.com/elastos/Elastos.DID.Method/blob/master/DID/Elastos-DID-Method-Specification_en.md)
2. [DID Verifiable Credentials Claims](https://github.com/elastos/Elastos.DID.Method/blob/master/VerifiableClaims/Elastos-Verifiable-Claims-Specification_en.md)
3. [DID Resolver](https://github.com/elastos/Elastos.DID.Method/blob/master/Resolver/Elastos-DID-Resolver-Specification_en.md)
4. [DID.Java.SDK](https://github.com/elastos/Elastos.DID.Java.SDK)
5. [ID.Sidechain](https://github.com/elastos/Elastos.ELA.Sidechain.ID)

Thank you for reviewing