### PR TITLE
Update location of Blockstack's DID method documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           Jude Nelson
       </td>
       <td>
-        <a href="https://github.com/blockstack/blockstack-core/blob/master/docs/blockstack-did-spec.md">Blockstack DID Method</a>
+         <a href="https://github.com/blockstack/blockstack-core/blob/stacks-1.0/docs/blockstack-did-spec.md">Blockstack DID Method</a>
       </td>
     </tr>
 


### PR DESCRIPTION
This PR just updates the URL to Blockstack's DID method description, which has moved into a different branch.