### PR TITLE
Register PalletOne DID Method

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           <a href="https://github.com/teleinfo-bif/bid/tree/master/doc/en">BIF DID Method</a>
         </td>
     </tr>
+    <tr>
+      <td>
+        did:ptn:
+      </td>
+      <td>
+        PROVISIONAL
+      </td>
+      <td>
+        PalletOne
+      </td>
+      <td>
+        PalletOne
+      </td>
+      <td>
+        <a href="https://github.com/palletone/palletone-DID/blob/master/docs/did-method/README.md">PalletOne DID Method</a>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
PalletOne is committed to creating the "IP protocol" of the blockchain world, decoupling blockchain applications from the underlying chain, and benchmarking and swapping the value of each blockchain token. PalletOne blockchain mainnet was officially launched on June 30, 2019 at 18:00 (UTC + 8). PalletOne mainnet browser is [here](https://www.palletone.info/). And you can know more about PalletOne at [here](http://pallet.one/). 

PalletOne DID is the DID implemented by PalletOne. It follows the W3C's DID specification and provides DID Method, Verifiable Credentials Claim and Resolve.

More information:
1. [DID Method](https://github.com/palletone/palletone-DID/blob/master/docs/did-method/palletone-did-syntaxes-zh-CN.md)
2. [DID Verifiable Credentials Claims](https://github.com/palletone/palletone-DID/blob/master/docs/sidetree-node/palletone-proof-claim-zh-CN.md)
3. [DID Resolver](https://github.com/palletone/palletone-DID/blob/master/docs/did-method/palletone-did-resolver-zh-CN.md)
4. [DID Opreation REST API](https://github.com/palletone/palletone-DID/blob/master/docs/sidetree-node/palletone-sidetree-rest-api-zh-CN.md)

+ @ studyzy

Thank you for reviewing.