### PR TITLE
Add Factom spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1118,6 +1118,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           <a href="https://github.com/Baasze/DID-method-specification">SAN DID Method</a>
         </td>
     </tr>
+    <tr>
+        <td>
+            did:factom:
+        </td>
+        <td>
+            PROVISIONAL
+        </td>
+        <td>
+            Factom
+        </td>
+        <td>
+            Sphereon, Factomatic, Factom Inc
+        </td>
+        <td>
+            <a href="https://github.com/factom-protocol/FIS/blob/master/FIS/DID.md">Factom DID Method</a>
+        </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Hi, this PR is to add the Factom DID method spec to the registry.

Spec: https://github.com/factom-protocol/FIS/blob/master/FIS/DID.md
Driver: https://github.com/Sphereon-Opensource/driver-did-factom