### PR TITLE
Update link to Github DID method spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,7 +1030,7 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           Transmute
         </td>
         <td>
-          <a href="https://github.com/decentralized-identity/github-did/blob/master/packages/docs/did-method-spec/spec.md">GitHub DID Method</a>
+          <a href="https://docs.github-did.com/did-method-spec/">GitHub DID Method</a>
         </td>
     </tr>
 <tr>


### PR DESCRIPTION
The spec was moved and the old link is broken